### PR TITLE
Populate сhangelog parameters from properties file.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/liquibase/evaluator/AbstractLiquibaseBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/liquibase/evaluator/AbstractLiquibaseBuilder.java
@@ -174,7 +174,7 @@ public abstract class AbstractLiquibaseBuilder extends Builder implements Simple
         liquibase.setChangeExecListener(new BuildChangeExecListener(action, listener));
 
         if (!Strings.isNullOrEmpty(changeLogParameters)) {
-            populateChangeLogParameters(liquibase, environment, changeLogParameters, resolveMacros);
+            populateChangeLogParameters(liquibase, environment, configProperties, changeLogParameters, resolveMacros);
         }
         return liquibase;
     }
@@ -204,7 +204,15 @@ public abstract class AbstractLiquibaseBuilder extends Builder implements Simple
 
     protected static void populateChangeLogParameters(Liquibase liquibase,
                                                       Map environment,
+                                                      Properties configProperties,
                                                       CharSequence changeLogParameters, boolean resolveMacros) {
+        for (Map.Entry entry : configProperties.entrySet()) {
+            String key = (String) entry.getKey();
+            if (key.startsWith("parameter.")) {
+                liquibase.setChangeLogParameter(key.replaceFirst("^parameter.", ""), entry.getValue());
+            }
+        }
+
         Map<String, String> keyValuePairs = Splitter.on("\n").trimResults().withKeyValueSeparator("=").split(changeLogParameters);
         for (Map.Entry<String, String> entry : keyValuePairs.entrySet()) {
             String value = entry.getValue();

--- a/src/test/java/org/jenkinsci/plugins/liquibase/evaluator/AbstractLiquibaseBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/liquibase/evaluator/AbstractLiquibaseBuilderTest.java
@@ -96,8 +96,8 @@ public class AbstractLiquibaseBuilderTest {
 
 
         String parameterValue = "red";
-        AbstractLiquibaseBuilder.populateChangeLogParameters(liquibase, new EnvVars(), "color=" + parameterValue,
-                true);
+        AbstractLiquibaseBuilder.populateChangeLogParameters(liquibase, new EnvVars(), liquibaseProperties,
+                "color=" + parameterValue, true);
 
         ChangeLogParameters changeLogParameters = liquibase.getChangeLogParameters();
         File changelog = temporaryFolder.newFile("changelog");


### PR DESCRIPTION
Implement standard liquibase feature - populate changelog parameters from properties file.
https://github.com/liquibase/liquibase/blob/ff5d7842ab73b90642582f27fddf3eb91088a863/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java#L610