### PR TITLE
Fix error when downloading multiple jdbc drivers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/liquibase/builder/AbstractLiquibaseBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/liquibase/builder/AbstractLiquibaseBuilder.java
@@ -124,7 +124,7 @@ public abstract class AbstractLiquibaseBuilder extends Builder implements Simple
         if (!Strings.isNullOrEmpty(installation.getDatabaseDriverUrl())) {
             Iterable<String> urls = Splitter.on(",").trimResults().split(installation.getDatabaseDriverUrl());
             for (String url : urls) {
-                String filename = url.substring(installation.getDatabaseDriverUrl().lastIndexOf("/") + 1);
+                String filename = url.substring(url.lastIndexOf("/") + 1);
                 File localJar = new File(installation.getHome(), "lib/" + filename);
                 if (!localJar.exists()) {
                     log.println("Downloading " + url + " to " + localJar);


### PR DESCRIPTION
The _databaseDriverUrl_ config property is a string potentially defining a comma-separated list of urls.
It is splitted and iterated on every single url, download the jdbc driver jar and detect a proper file name for it (among other things).
Unfortunately the filename detection throws a _StringIndexOutOfBoundsException_ when the _databaseDriverUrl_ config property has multiple urls (i.e. _https://jdbc.postgresql.org/download/postgresql-42.2.20.jar,https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/21.1.0.0/ojdbc11-21.1.0.0.jar_).

It probably meant to use the substring from the last index of the "/" separator to the end of the url,
but it uses the position from the whole _databaseDriverUrl_ property (unsplitted).

This fix proposes to get the last index of the "/" separator from the currently processed driver url
in order to compute the jar file name, so trying to follow the intention of the author.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
