### PR TITLE
remove erronous dependency on cloudbees-credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.cloudbees.jenkins.plugins</groupId>
-            <artifactId>cloudbees-credentials</artifactId>
-            <version>3.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.29</version>


### PR DESCRIPTION
the plugin erroneously depended on `cloudbees-credentials` which is a deprecated plugin that is used to provide credentials to access CloudBees services.

remove the dependency requirement so that people can remove the unused dependency

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

@r2liquibase 